### PR TITLE
Mobile now uses normal scrollbar instead of custom for desktop.  This…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3280,12 +3280,6 @@ input[type="date"]::-webkit-inner-spin-button{
   transition-delay: 0;
 }
 
-html, body{
-    height:100%;
-    margin:0;
-    padding:0;
-    overflow:hidden;
-}
 .schedule tr {
     border-bottom: 1px solid #DBDCDC;
 }

--- a/prototype8.html
+++ b/prototype8.html
@@ -110,7 +110,7 @@
 			});
 		</script>
 	</head>
-	<body data-spy="scroll" data-target=".scrollspy" ng-controller="NavListController as navListCtrl" get-body-dimensions>
+	<body data-spy="scroll" data-target=".scrollspy" ng-controller="NavListController as navListCtrl" get-body-dimensions ng-style="navListCtrl.bodyStyle">
 		<div id="site-container" style="height: 100%">
 			<header class="header navbar left-slide">
 				<div class="container container-fluid-max-lg">
@@ -1011,7 +1011,7 @@
 									</div>
 								</div>
 								<!-- For below Medium screen sizes -->
-								<div id="isoContainerMobile" ng-cloak class="hidden-md hidden-lg hidden-xl ng-cloak" infinite-scroll="navListCtrl.loadMore('mobile')" infinite-scroll-distance="1" infinite-scroll-target-container="#bottomContainer">
+								<div id="isoContainerMobile" ng-cloak class="hidden-md hidden-lg hidden-xl ng-cloak" infinite-scroll="navListCtrl.loadMore('mobile')" infinite-scroll-distance="1">
 									<div ng-repeat="classInfo in navListCtrl.onscreenResults | limitTo: navListCtrl.limit" class="itemBox mixFirst col-xs-12 col-sm-6 col-md-3 pl10 pr10" ng-class="{'col-lg-6 featured': classInfo.Featured, 'col-lg-3': !classInfo.Featured}">
 										<div class="itemContents hidden-xs">
 											<a ng-href="http://www.92y.org{{classInfo.Url}}">

--- a/src/navControllers5.js
+++ b/src/navControllers5.js
@@ -104,7 +104,8 @@
 		self.debounceSearch = _.debounce(function () { self.modifyUrlSearch(false); }, 2000);
 		self.applyScope = function () { $scope.$apply(); };
 		self.enabledFilters = {};
-		self.bottomContainerStyle = { 'overflow': 'scroll', '-webkit-overflow-scrolling': 'touch', 'overflow-x': 'hidden', 'height': '100%' };
+		self.bottomContainerStyle = { 'overflow': 'overflow', 'overflow-x': 'hidden', 'height': '100%' };
+		self.bodyStyle = { 'height': '100%', 'margin': '0', 'padding': '0', 'overflow': 'hidden' };
 		self.chunkLevels = [];
 		self.affixed = false;
 		self.scrollingUp = false;
@@ -1904,6 +1905,7 @@ var isDate = function (checkDate) {
 var resizeTileDisplay = function (scope) {
 
 	var tileHeight, numColumns;
+	scope.navListCtrl.environment = "desktop";
 	if (window.matchMedia( "(min-width: 1200px)" ).matches) {
 		numColumns = 1;
 		tileHeight = 211;
@@ -1917,6 +1919,14 @@ var resizeTileDisplay = function (scope) {
 		numColumns = 1;
 		tileHeight = 135;
 		scope.navListCtrl.environment = "mobile";
+	}
+
+	if (scope.navListCtrl.environment === "mobile") {
+		scope.navListCtrl.bodyStyle = {};
+		scope.navListCtrl.bottomContainerStyle = { '-webkit-overflow-scrolling': 'touch' };
+	} else {
+		scope.navListCtrl.bodyStyle = { 'height': '100%', 'margin': '0', 'padding': '0', 'overflow': 'hidden' };
+		scope.navListCtrl.bottomContainerStyle = { 'overflow': 'overflow', 'overflow-x': 'hidden', 'height': '100%' };
 	}
 
 	var headerHeight = $("#Container").offset().top;


### PR DESCRIPTION
… is so the display will redraw correctly when it goes from landscape to portrait after a refresh.  Mobile devices are bad with overflow:scroll CSS entries.